### PR TITLE
Modified lxml and django versions, small synch_hashes fix

### DIFF
--- a/olaaf_django/sync_hashes.py
+++ b/olaaf_django/sync_hashes.py
@@ -7,14 +7,15 @@ from git import Repo
 from datetime import datetime
 from selenium import webdriver
 from urllib.parse import urlparse
+from selenium.webdriver.chrome.options import Options
 from lxml import etree as et
 from olaaf_django.models import Commit, Path, Hash, Edition, Repository
 from olaaf_django.utils import calc_hash, get_auth_div_content, get_html_document
 
-
-options = webdriver.ChromeOptions()
-options.add_argument("headless")
-driver = webdriver.Chrome(chrome_options=options)
+chrome_options = Options()
+chrome_options.add_argument("--headless")
+chrome_options.add_argument('--no-sandbox')
+driver = webdriver.Chrome(chrome_options=chrome_options)
 
 EMPTY_TREE_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
 # currently supported file types

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Django >= 2.2.5
+Django >= 2.0
 GitPython >= 2.1.11
 selenium >= 3.141.0
-lxml >= 4.3.4
+lxml >= 4.3
 click==6.7

--- a/setup.py
+++ b/setup.py
@@ -50,10 +50,10 @@ setup(
     ],
     zip_safe=False,
     install_requires=[
-        'Django >= 2.2.3',
+        'Django >= 2.0',
         'GitPython >= 2.1.11',
         'selenium >= 3.141.0',
-        'lxml >= 4.3.4',
+        'lxml >= 4.3',
     ],
     extras_require={
         'ci': ci_require,


### PR DESCRIPTION
- lxml and django versions can be in conflict with proejcts which have OLAAF-Transient as a dependency, so it's better not to specify a strict version
- Fixed chrome options in sync_hashes