### PR TITLE
Transition to the new TAF

### DIFF
--- a/olaaf_django/__init__.py
+++ b/olaaf_django/__init__.py
@@ -4,7 +4,6 @@ import mimetypes
 from pathlib import Path
 
 from django.http import Http404
-from taf.auth_repo import AuthenticationRepo
 from taf.repositoriesdb import get_repositories_paths_by_custom_data
 
 logger = logging.getLogger('django')

--- a/olaaf_django/sync_hashes.py
+++ b/olaaf_django/sync_hashes.py
@@ -506,7 +506,7 @@ def _get_file_content_and_document(repo, commit_sha, file_path, file_type, chrom
     # elements such as authentication div, search path and url
     doc = _get_document(file_content, chrome_driver)
   else:
-    file_content = GitRepository(repo.git_dir).get_file(commit_sha, file_path, raw=True)
+    file_content = GitRepository(path=repo.git_dir).get_file(commit_sha, file_path, raw=True)
 
   return file_content, doc
 

--- a/olaaf_django/tests/conftest.py
+++ b/olaaf_django/tests/conftest.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 import pytest
 from lxml import html
 from selenium import webdriver
-from taf.git import NamedGitRepository
+from taf.git import GitRepository
 
 from olaaf_django.sync_hashes import chrome_options
 
@@ -113,7 +113,7 @@ NON_PUBLICATION_BRANCHES = {
 @pytest.fixture(scope='session')
 def html_repository_and_input():
   try:
-    repo = NamedGitRepository(LIBRARY_ROOT, HTML_REPO_NAME)
+    repo = GitRepository(LIBRARY_ROOT, HTML_REPO_NAME)
     repo.init_repo()
     repos_data = _init_pub_branches(repo)
     yield repo, repos_data

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = 'olaaf-transient'
-VERSION = '0.10.0'
+VERSION = '0.11.0'
 AUTHOR = 'Open Law Library'
 AUTHOR_EMAIL = 'info@openlawlib.org'
 DESCRIPTION = 'Implementation of transient authentication'
@@ -54,7 +54,7 @@ setup(
         'GitPython >= 2.1.11',
         'selenium ~= 3.0',
         'lxml >= 4.3',
-        'taf >= 0.6',
+        'taf >= 0.9',
     ],
     extras_require={
         'ci': ci_require,


### PR DESCRIPTION
Named git repositories were removed. The repositories can be instantiated either
by providing library dir and name or full path.