### PR TITLE
Do not raise an error if hosts repos cache cannot be loaded from settings and update Django version

### DIFF
--- a/olaaf_django/__init__.py
+++ b/olaaf_django/__init__.py
@@ -15,8 +15,7 @@ def set_hosts_repos_cache_from_settings(settings):
     global HOSTS_REPOS_CACHE
     HOSTS_REPOS_CACHE = settings.HOSTS_REPOS_CACHE
   except AttributeError:
-    logger.error("Could not read 'HOSTS_REPOS_CACHE ' from settings")
-    raise Exception("Could not read 'HOSTS_REPOS_CACHE ' from settings")
+    logger.error("Could not read 'HOSTS_REPOS_CACHE' from settings")
 
 
 def get_repo_by_host(host):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = 'olaaf-transient'
-VERSION = '0.21.0'
+VERSION = '0.22.0'
 AUTHOR = 'Open Law Library'
 AUTHOR_EMAIL = 'info@openlawlib.org'
 DESCRIPTION = 'Implementation of transient authentication'
@@ -27,7 +27,7 @@ dev_require = [
 ]
 
 tests_require = [
-    "pytest-django==4.5.*",
+    "pytest-django==4.*",
     "pytest==6.*",
 ]
 
@@ -51,7 +51,7 @@ setup(
     ],
     zip_safe=False,
     install_requires=[
-        "Django >= 2.2",
+        "Django >= 3.2.*",
         "GitPython >= 2.1.11",
         "selenium ~= 3.0",
         "lxml >= 4.3",


### PR DESCRIPTION
Do not raise an error if hosts repos cache cannot be loaded from settings. This breaks Django apps that include OLAAF.
Update Django version
